### PR TITLE
Provide a _raw_ filehandle to HTTP::Request::StreamingUpload

### DIFF
--- a/lib/Artifactory/Client.pm
+++ b/lib/Artifactory/Client.pm
@@ -631,10 +631,11 @@ sub deploy_artifact {
     push @joiners, $props if ($props);    # if properties aren't passed in, the function returns empty string
 
     my $url = join( ";", @joiners );
+    my $fh = Path::Tiny::path($file)->openr_raw();
     my $req = HTTP::Request::StreamingUpload->new(
         PUT     => $url,
-        path    => $file,
-        headers => HTTP::Headers->new( %{$header} ),
+        fh      => $fh,
+        headers => HTTP::Headers->new( %{$header}, 'Content-Length' => -s $fh, ),
     );
     return $self->request($req);
 }


### PR DESCRIPTION
This is to work-around how HTTP::Request::StreamingUpload handles
files [1].

When using this module on a Windows server, Artifactory was rejecting
deploys due to bad checksums.

[1] https://github.com/yappo/p5-HTTP-Request-StreamingUpload/pull/1
