### PR TITLE
Allow zero byte files, or no files for deploy_artifact

### DIFF
--- a/lib/Artifactory/Client.pm
+++ b/lib/Artifactory/Client.pm
@@ -631,11 +631,10 @@ sub deploy_artifact {
     push @joiners, $props if ($props);    # if properties aren't passed in, the function returns empty string
 
     my $url = join( ";", @joiners );
-    my $fh = Path::Tiny::path($file)->openr_raw();
     my $req = HTTP::Request::StreamingUpload->new(
         PUT     => $url,
-        fh      => $fh,
-        headers => HTTP::Headers->new( %{$header}, 'Content-Length' => -s $fh, ),
+        headers => HTTP::Headers->new( %{$header} ),
+        ( $file ? ( fh => Path::Tiny::path($file)->openr_raw() ) : () ),
     );
     return $self->request($req);
 }


### PR DESCRIPTION
fixes test failures in #4 
